### PR TITLE
update rewardScore calculation that assumes rewards in 'sparks'

### DIFF
--- a/app/api/zora/collections/route.ts
+++ b/app/api/zora/collections/route.ts
@@ -33,7 +33,6 @@ export async function GET(request: NextRequest) {
     const collections = Object.values(aggregatedData).map((collection: any) => {
       const chain = collection.metadata.uniqueId.split('-')[0];
       const chainId = getChainId(chain);
-
       return {
         tokensCreated: collection.points,
         address: collection.metadata.collection,

--- a/app/api/zora/collections/route.ts
+++ b/app/api/zora/collections/route.ts
@@ -33,6 +33,7 @@ export async function GET(request: NextRequest) {
     const collections = Object.values(aggregatedData).map((collection: any) => {
       const chain = collection.metadata.uniqueId.split('-')[0];
       const chainId = getChainId(chain);
+
       return {
         tokensCreated: collection.points,
         address: collection.metadata.collection,

--- a/lib/consts.tsx
+++ b/lib/consts.tsx
@@ -39,3 +39,7 @@ export const MAX_REWARD_SCORE = 0.222;
 export const TOKEN_INDEXER_POINT_ID = 3500;
 export const REWARDS_DEPOSIT_POINT_SYSTEM_ID = 4272;
 export const SETTINGS_STACK_ID = 3067;
+
+//conversions
+
+export const ETH_TO_SPARKS = Math.pow(10, 6);

--- a/lib/consts.tsx
+++ b/lib/consts.tsx
@@ -33,12 +33,9 @@ export const EVENT_ZORA_PROFILE = 'zora+profile';
 export const FOLLOWERS_PERFECT = 55555;
 export const MAX_CREATE_SCORE = 111;
 export const SCORE_FACTOR = 0.33;
-export const MAX_REWARD_SCORE = 0.222;
+export const MAX_REWARD_SCORE = 222000;
 
 // stack point systems
 export const TOKEN_INDEXER_POINT_ID = 3500;
 export const REWARDS_DEPOSIT_POINT_SYSTEM_ID = 4272;
 export const SETTINGS_STACK_ID = 3067;
-
-//conversions
-export const ETH_TO_SPARKS = Math.pow(10, 6);

--- a/lib/consts.tsx
+++ b/lib/consts.tsx
@@ -41,5 +41,4 @@ export const REWARDS_DEPOSIT_POINT_SYSTEM_ID = 4272;
 export const SETTINGS_STACK_ID = 3067;
 
 //conversions
-
 export const ETH_TO_SPARKS = Math.pow(10, 6);

--- a/lib/zora/score/getRewardScore.tsx
+++ b/lib/zora/score/getRewardScore.tsx
@@ -1,7 +1,6 @@
-import { ETH_TO_SPARKS, MAX_REWARD_SCORE } from '@/lib/consts';
+import { MAX_REWARD_SCORE } from '@/lib/consts';
 
 export function getRewardScore(totalRewards: number) {
-  const totalRewardsInETH = totalRewards / ETH_TO_SPARKS;
-  const rewardScore = Math.min(totalRewardsInETH / MAX_REWARD_SCORE, 1) * 100;
+  const rewardScore = Math.min(totalRewards / MAX_REWARD_SCORE, 1) * 100;
   return parseFloat(rewardScore.toFixed(2));
 }

--- a/lib/zora/score/getRewardScore.tsx
+++ b/lib/zora/score/getRewardScore.tsx
@@ -1,9 +1,7 @@
-import { MAX_REWARD_SCORE } from '@/lib/consts';
-import { formatEther } from 'viem';
+import { ETH_TO_SPARKS, MAX_REWARD_SCORE } from '@/lib/consts';
 
 export function getRewardScore(totalRewards: number) {
-  const totalRewardsInBigInt = BigInt(totalRewards);
-  const totalRewardsInETH = parseFloat(formatEther(totalRewardsInBigInt));
-  const rewardScore = (totalRewardsInETH / MAX_REWARD_SCORE) * 100;
+  const totalRewardsInETH = totalRewards / ETH_TO_SPARKS;
+  const rewardScore = Math.min(totalRewardsInETH / MAX_REWARD_SCORE, 1) * 100;
   return parseFloat(rewardScore.toFixed(2));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced API for retrieving token events related to Zora collections, now supporting filtering by creator address.
	- Introduced a new conversion constant for ETH to SPARKS.

- **Bug Fixes**
	- Improved logic for calculating reward scores, ensuring accurate scoring capped at 100%.

- **Documentation**
	- Added comments to clarify the purpose of new constants and functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->